### PR TITLE
Update demostf for usage with neocurl

### DIFF
--- a/demostf.sp
+++ b/demostf.sp
@@ -15,7 +15,7 @@ public Plugin myinfo =
 int CURL_Default_opt[][2] = {
 	{ view_as<int>(CURLOPT_NOSIGNAL),               1 }, 
 	{ view_as<int>(CURLOPT_NOPROGRESS),             1 }, 
-	{ view_as<int>(CURLOPT_TIMEOUT),                30 }, 
+	{ view_as<int>(CURLOPT_TIMEOUT),                60 }, 
 	{ view_as<int>(CURLOPT_CONNECTTIMEOUT),         30 }, 
 	{ view_as<int>(CURLOPT_USE_SSL),                CURLUSESSL_ALL }, 
 	{ view_as<int>(CURLOPT_VERBOSE),                0 }

--- a/demostf.sp
+++ b/demostf.sp
@@ -8,7 +8,7 @@ public Plugin myinfo =
 	name = "demos.tf uploader",
 	author = "Icewind / sappho.io",
 	description = "Auto-upload match stv to demos.tf",
-	version = "0.3.2-beta-sappho",
+	version = "0.3.2",
 	url = "https://demos.tf"
 };
 


### PR DESCRIPTION
Neocurl is a maintained version of the now broken curl extension.

demostf uploads are exceedingly spotty with it (the old version) due to some abi changes in sourcemod 1.11 as well as the version of curl it uses being too old to actually function in most environments (e.g. cert bundle issues).

Also, I added better logging and went ahead and changed the curlcode error to an actual message so people don't just throw numbers at me when things break.

***Please update your CICD to compile with Sourcemod 1.11, otherwise the plugin downloaded from the website will continue to not work for some people.***

Thanks!